### PR TITLE
ci: переход с jitpack на Maven Central через JReleaser

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,22 @@
+name: javadoc
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-javadoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
+      - name: Check javadoc build
+        run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -1,0 +1,37 @@
+name: Publish to maven central
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
+      - name: Deploy to Central Portal
+        run: |
+          ./gradlew publishMavenPublicationToStagingRepository
+          ./gradlew jreleaserDeploy
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_SIGNING_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          JRELEASER_DEPLOY_MAVEN_NEXUS2_SNAPSHOT_DEPLOY_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_DEPLOY_MAVEN_NEXUS2_SNAPSHOT_DEPLOY_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Upload release asset
+
+on:
+    release:
+        types: [published]
+
+permissions:
+    contents: write
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v6
+          with:
+            fetch-depth: 0
+            persist-credentials: false
+        - uses: actions/setup-java@v5
+          with:
+            java-version: 21
+            distribution: 'temurin'
+        - run: ./gradlew build
+        - uses: AButler/upload-release-assets@v4.0
+          with:
+            files: './build/libs/*.jar'
+            repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,40 @@
+import org.jreleaser.model.Active.*
+
 plugins {
     id("java")
     id("java-library")
     `maven-publish`
+    id("me.qoomon.git-versioning") version "6.4.4"
+    id("io.freefair.javadoc-links") version "9.2.0"
+    id("io.freefair.javadoc-utf-8") version "9.2.0"
+    id("io.freefair.maven-central.validate-poms") version "9.2.0"
+    id("ru.vyarus.pom") version "3.0.0"
+    id("org.jreleaser") version "1.24.0"
 }
 
 group = "io.github.1c-syntax"
+gitVersioning.apply {
+    refs {
+        describeTagFirstParent = false
+        tag("v(?<tagVersion>[0-9].*)") {
+            version = "\${ref.tagVersion}\${dirty}"
+        }
 
-version = "0.1.0-SNAPSHOT"
+        branch("master") {
+            version = "\${describe.tag.version.major}." +
+                    "\${describe.tag.version.minor.next}.0." +
+                    "\${describe.distance}-SNAPSHOT\${dirty}"
+        }
+
+        branch(".+") {
+            version = "\${ref.slug}-\${commit.short}\${dirty}"
+        }
+    }
+
+    rev {
+        version = "\${commit.short}\${dirty}"
+    }
+}
 
 java {
     toolchain {
@@ -18,14 +46,10 @@ java {
 
 repositories {
     mavenCentral()
-    // bsl-help-toc-parser подключаем через jitpack по SHA коммита master:
-    // версия 0.2.0 (переход на 1c-syntax fork ANTLR + Java 21) ещё не
-    // опубликована в Maven Central, на jitpack доступна сразу после merge.
-    maven(url = "https://jitpack.io")
 }
 
 dependencies {
-    implementation("com.github.1c-syntax:bsl-help-toc-parser:4452a79")
+    implementation("io.github.1c-syntax:bsl-help-toc-parser:0.2.0")
     implementation("org.jsoup:jsoup:1.18.3")
 
     compileOnly("org.projectlombok:lombok:1.18.34")
@@ -35,13 +59,18 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.34")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
-    // https://mvnrepository.com/artifact/org.assertj/assertj-core
     testImplementation("org.assertj:assertj-core:3.27.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
 }
 
 publishing {
+    repositories {
+        maven {
+            name = "staging"
+            url = layout.buildDirectory.dir("staging-deploy").get().asFile.toURI()
+        }
+    }
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
@@ -57,11 +86,76 @@ publishing {
                     license {
                         name.set("LGPL-3.0-or-later")
                         url.set("https://www.gnu.org/licenses/lgpl-3.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("sfaqer")
+                        name.set("Kirill Chernenko")
+                        email.set("faqer2012@gmail.com")
+                        url.set("https://github.com/sfaqer")
+                        organization.set("1c-syntax")
+                        organizationUrl.set("https://github.com/1c-syntax")
+                    }
+                    developer {
+                        id.set("otymko")
+                        name.set("Oleg Tymko")
+                        email.set("olegtymko@yandex.ru")
+                        url.set("https://github.com/otymko")
+                        organization.set("1c-syntax")
+                        organizationUrl.set("https://github.com/1c-syntax")
+                    }
+                    developer {
+                        id.set("alkoleft")
+                        name.set("alkoleft")
+                        email.set("alkoleft@gmail.com")
+                        url.set("https://github.com/alkoleft")
+                        organization.set("1c-syntax")
+                        organizationUrl.set("https://github.com/1c-syntax")
                     }
                 }
                 scm {
+                    connection.set("scm:git:git://github.com/1c-syntax/bsl-context.git")
+                    developerConnection.set("scm:git:git@github.com:1c-syntax/bsl-context.git")
                     url.set("https://github.com/1c-syntax/bsl-context")
-                    connection.set("scm:git:https://github.com/1c-syntax/bsl-context.git")
+                }
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("https://github.com/1c-syntax/bsl-context/issues")
+                }
+                ciManagement {
+                    system.set("GitHub Actions")
+                    url.set("https://github.com/1c-syntax/bsl-context/actions")
+                }
+            }
+        }
+    }
+}
+
+jreleaser {
+    signing {
+        active = ALWAYS
+        armored = true
+    }
+    deploy {
+        maven {
+            mavenCentral {
+                create("release-deploy") {
+                    active = RELEASE
+                    url = "https://central.sonatype.com/api/v1/publisher"
+                    stagingRepository("build/staging-deploy")
+                }
+            }
+            nexus2 {
+                create("snapshot-deploy") {
+                    active = SNAPSHOT
+                    snapshotUrl = "https://central.sonatype.com/repository/maven-snapshots/"
+                    applyMavenCentralRules = true
+                    snapshotSupported = true
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepository("build/staging-deploy")
                 }
             }
         }
@@ -74,12 +168,18 @@ tasks.withType<Javadoc> {
         encoding = "UTF-8"
         charSet = "UTF-8"
         addStringOption("Xdoclint:none", "-quiet")
+        links("https://javadoc.io/doc/org.jsoup/jsoup/latest")
     }
 }
+
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
 }
 
 tasks.withType<JavaCompile>() {
     options.encoding = "UTF-8"
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    dependsOn(tasks.validatePomFiles)
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-jdk:
-  - openjdk21
-
-install:
-  - ./gradlew clean publishToMavenLocal -x test


### PR DESCRIPTION
- добавлены workflow для javadoc, релизных ассетов и публикации в Maven Central
- build.gradle.kts: git-versioning, jreleaser, freefair javadoc/pom плагины,
  расширенный pom (developers, scm, issueManagement, ciManagement)
- зависимость bsl-help-toc-parser переключена с jitpack на Maven Central
- удалён jitpack.yml

https://claude.ai/code/session_01Ag4KRCewJZkSFXtY7BPv8p